### PR TITLE
Create Kangaroo_Driver_Lib.h

### DIFF
--- a/Kangaroo_Driver_Lib.h
+++ b/Kangaroo_Driver_Lib.h
@@ -1,0 +1,21 @@
+#ifndef Kangaroo_Driver_Lib_h
+#define Kangaroo_Driver_Lib_h
+
+#include "COMMAND_LIST.h"
+#include "mraa.h"
+#include <unistd.h>
+
+/**********************************************************************************************
+ * FUNCTION PROTOTYPES
+ *********************************************************************************************/
+
+    mraa_uart_context uart_setup();
+
+    uint16_t crc14(const uint8_t* data, size_t length);
+
+    size_t write_kangaroo_command(uint8_t address, uint8_t command, const uint8_t* data,
+                                  uint8_t length, uint8_t* buffer);
+
+    void start_channel(uint8_t address, uint8_t channel_name);
+
+#endif // Kangaroo_Driver_Lib_h


### PR DESCRIPTION
First version for the Kangaroo Driver Library. Contains headers for the functions of the Kangaroo_Driver_Lib.c file. Not tested on the Kangaroo yet.
